### PR TITLE
Fix voice state handler imports

### DIFF
--- a/modules/handleVoiceStateUpdate.js
+++ b/modules/handleVoiceStateUpdate.js
@@ -2,8 +2,8 @@ const { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerSta
 const path = require('path');
 const fs = require('fs');
 const ffmpeg = require('fluent-ffmpeg');
-const { textToSpeech } = require('../tts');
-const { transcribeAudio } = require('../transcription');
+const textToSpeech = require('../tts');
+const transcribeAudio = require('../transcription');
 
 module.exports = (client, logger, botConfig) => async (oldState, newState) => {
     const user = newState.member.user;


### PR DESCRIPTION
## Summary
- simplify module imports in `handleVoiceStateUpdate`

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845706de3488323a1789085e38df0d3