### PR TITLE
Fix env path in transcription module

### DIFF
--- a/transcription.js
+++ b/transcription.js
@@ -3,7 +3,7 @@ const { SpeechClient } = require('@google-cloud/speech');
 const winston = require('winston');
 const path = require('path');
 const { config } = require('dotenv');
-config({ path: path.resolve(__dirname, '..', '.env') });
+config({ path: path.resolve(__dirname, '.env') });
 
 const speechClient = new SpeechClient();
 


### PR DESCRIPTION
## Summary
- use `.env` from project root

## Testing
- `npm test`
- `node index.js` *(fails: ENETUNREACH when connecting to Discord)*

------
https://chatgpt.com/codex/tasks/task_e_68457622ae508323aafdf6da6c0d601a