### PR TITLE
Add logger to tts.js

### DIFF
--- a/modules/handleVoiceStateUpdate.js
+++ b/modules/handleVoiceStateUpdate.js
@@ -35,7 +35,7 @@ const sendWelcomeMessage = async (connection, user, logger, botConfig, client) =
 
     try {
         logger.info(`Generating TTS for text: ${greetingMessage}`);
-        await textToSpeech(greetingMessage, ttsFile);
+        await textToSpeech(greetingMessage, ttsFile, logger);
         logger.info(`TTS audio file created at: ${ttsFile}`);
 
         if (!fs.existsSync(ttsFile) || fs.statSync(ttsFile).size === 0) {


### PR DESCRIPTION
## Summary
- use a winston logger inside `tts.js`
- wire up `textToSpeech` so caller can provide logger
- log info messages via logger instead of `console.log`
- forward logger when calling `textToSpeech`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68457c8f9494832387e206aecffe5842