### PR TITLE
Remove duplicate dotenv loading

### DIFF
--- a/transcription.js
+++ b/transcription.js
@@ -1,9 +1,6 @@
 const fs = require('fs/promises');
 const { SpeechClient } = require('@google-cloud/speech');
 const winston = require('winston');
-const path = require('path');
-const { config } = require('dotenv');
-config({ path: path.resolve(__dirname, '.env') });
 
 const speechClient = new SpeechClient();
 

--- a/tts.js
+++ b/tts.js
@@ -1,9 +1,6 @@
 const axios = require('axios');
 const fs = require('fs/promises');
 const winston = require('winston');
-const path = require('path');
-const { config } = require('dotenv');
-config({ path: path.resolve(__dirname, '.env') });
 
 const ELEVEN_LABS_API_KEY = process.env.ELEVEN_LABS_API_KEY;
 const ELEVEN_LABS_VOICE_ID = process.env.ELEVEN_LABS_VOICE_ID;


### PR DESCRIPTION
## Summary
- remove duplicated dotenv configuration from `tts.js` and `transcription.js`
- environment variables are now loaded only via `index.js`

## Testing
- `npm install`
- `npm test`
- `node index.js` *(fails to connect to Discord because of dummy credentials but loads env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68457d436e9083239a42bab54c0e075c