### PR TITLE
Add npm start script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Create a `.env` file in the project root with the following variables:
 After creating the `.env` file and installing dependencies, start the bot with:
 
 ```bash
-node index.js
+npm start
 ```
+
+This command runs `node index.js` internally to launch the bot.
 
 The bot will connect to Discord using the provided token and begin listening for voice channel events.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "bot.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `start` script to `package.json`
- document usage of `npm start` in README

## Testing
- `npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_68457e177eec8323882af2f274c23b8f