### PR TITLE
Ensure env vars loaded via index.js

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -5,8 +5,7 @@ const path = require('path');
 const fs = require('fs/promises');
 const botConfig = require('./config.json');
 
-// Load environment variables
-config({ path: path.resolve(__dirname, '.env') });
+// Environment variables are loaded in index.js
 
 // Environment variables
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 // index.js
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 require('./bot');


### PR DESCRIPTION
## Summary
- remove dotenv config call from `bot.js`
- load env vars from `index.js` with a fixed `.env` path

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6846c284ec108323be8404b6361814dc