### PR TITLE
Clean up audio files after transcription

### DIFF
--- a/modules/handleVoiceStateUpdate.js
+++ b/modules/handleVoiceStateUpdate.js
@@ -109,6 +109,18 @@ const startRecordingAndTranscription = async (connection, user, logger) => {
                 } else {
                     logger.error('Failed to transcribe audio.');
                 }
+
+                try {
+                    await fsPromises.unlink(audioFilePath);
+                } catch (err) {
+                    logger.warn(`Failed to delete ${audioFilePath}: ${err.message}`);
+                }
+
+                try {
+                    await fsPromises.unlink(wavFilePath);
+                } catch (err) {
+                    logger.warn(`Failed to delete ${wavFilePath}: ${err.message}`);
+                }
             });
     });
 };


### PR DESCRIPTION
## Summary
- remove temporary PCM and WAV files once `transcribeAudio` completes
- warn if deletion fails

## Testing
- `npx -y jest`

------
https://chatgpt.com/codex/tasks/task_e_6846cd355e9883239c28f0e28cf35171