### PR TITLE
Remove unused dotenv import from bot.js

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,4 @@
 const { Client, GatewayIntentBits } = require('discord.js');
-const { config } = require('dotenv');
 const winston = require('winston');
 const path = require('path');
 const fs = require('fs/promises');


### PR DESCRIPTION
## Summary
- drop `require('dotenv')` from `bot.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846d0a9c9a48323af9961015ca661cd