### PR TITLE
Switch to logger.error

### DIFF
--- a/modules/handleVoiceStateUpdate.js
+++ b/modules/handleVoiceStateUpdate.js
@@ -103,7 +103,7 @@ const startRecordingAndTranscription = async (connection, user, logger) => {
             .save(wavFilePath)
             .on('end', async () => {
                 logger.info(`Saved WAV file: ${wavFilePath}`);
-                const transcription = await transcribeAudio(wavFilePath);
+                const transcription = await transcribeAudio(wavFilePath, logger);
                 if (transcription) {
                     logger.info(`Transcription: ${transcription}`);
                 } else {

--- a/transcription.js
+++ b/transcription.js
@@ -2,9 +2,19 @@ const fs = require('fs/promises');
 const { SpeechClient } = require('@google-cloud/speech');
 const winston = require('winston');
 
+const defaultLogger = winston.createLogger({
+    level: 'info',
+    format: winston.format.json(),
+    defaultMeta: { service: 'transcription-service' },
+    transports: [
+        new winston.transports.Console(),
+        new winston.transports.File({ filename: 'bot.log' })
+    ]
+});
+
 const speechClient = new SpeechClient();
 
-const transcribeAudio = async (audioFilePath) => {
+const transcribeAudio = async (audioFilePath, logger = defaultLogger) => {
     try {
         const file = await fs.readFile(audioFilePath);
         const audioBytes = file.toString('base64');
@@ -32,7 +42,7 @@ const transcribeAudio = async (audioFilePath) => {
 
         return transcription;
     } catch (error) {
-        winston.error(`Error in transcribeAudio: ${error}`);
+        logger.error(`Error in transcribeAudio: ${error}`);
         return null;
     }
 };

--- a/tts.js
+++ b/tts.js
@@ -29,18 +29,18 @@ const textToSpeech = async (text, filename = 'tts.mp3', logger = defaultLogger) 
             const stats = await fs.stat(filename);
             logger.info(`TTS file size: ${stats.size} bytes`);
             if (stats.size === 0) {
-                winston.error('TTS file is empty.');
+                logger.error('TTS file is empty.');
             } else {
                 logger.info('TTS file created successfully.');
             }
         } else {
-            winston.error(`Request failed with status code: ${response.status}`);
-            winston.error(`Response data: ${JSON.stringify(response.data)}`);
+            logger.error(`Request failed with status code: ${response.status}`);
+            logger.error(`Response data: ${JSON.stringify(response.data)}`);
         }
     } catch (error) {
-        winston.error(`Error in textToSpeech: ${error}`);
+        logger.error(`Error in textToSpeech: ${error}`);
         if (error.response) {
-            winston.error(`Response data: ${JSON.stringify(error.response.data)}`);
+            logger.error(`Response data: ${JSON.stringify(error.response.data)}`);
         }
     }
 };


### PR DESCRIPTION
## Summary
- switch from `winston.error` to `logger.error`
- allow passing a logger to `transcribeAudio`
- forward logger in `handleVoiceStateUpdate`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d2cb59008323af306cc9e750bca7