### PR TITLE
Add trimming for splitResponse and new Jest test

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -20,13 +20,14 @@ const loadBannedWords = async (filePath) => {
 
 const splitResponse = (response, max_length = 200) => {
     const parts = [];
+    response = response.trim();
     while (response.length > max_length) {
         let split_at = response.lastIndexOf(' ', max_length);
         if (split_at === -1) split_at = max_length;
-        parts.push(response.substring(0, split_at));
+        parts.push(response.substring(0, split_at).trim());
         response = response.substring(split_at).trim();
     }
-    parts.push(response);
+    if (response.length > 0) parts.push(response.trim());
     return parts;
 };
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -40,6 +40,11 @@ describe('splitResponse', () => {
     expect(parts).toEqual(['hello world']);
   });
 
+  test('trims trailing spaces in input', () => {
+    const parts = splitResponse('hello world   ', 20);
+    expect(parts).toEqual(['hello world']);
+  });
+
   test('splits long string at spaces', () => {
     const text = 'The quick brown fox jumps over the lazy dog';
     const parts = splitResponse(text, 10);


### PR DESCRIPTION
## Summary
- ensure `splitResponse` trims trailing spaces
- add Jest test for trailing spaces in input

## Testing
- `npx jest tests/utils.test.js --runInBand --silent`


------
https://chatgpt.com/codex/tasks/task_e_6846db1fee9c832385854b94cef598cc